### PR TITLE
docs: outline project plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS
+
+These instructions guide AI contributors working on this repository.
+
+- Review `README.md` for the overall project vision and technical stack.
+- Review `TODO.md` for the current roadmap and open tasks.
+- Before making changes, ask the user clarifying questions to confirm intent.
+- Provide detailed explanations in commits and pull requests so other agents without context can follow.
+- Use conventional commit messages (e.g., `docs:`, `feat:`, `fix:`).
+- Run `npm test` or other relevant checks after modifications and include the results.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
 # LearnWithManga
+
+LearnWithManga is a long‑term project aimed at turning the passive Japanese vocabulary
+picked up from watching manga and anime into active language skills. The app mixes
+AI‑assisted flashcards, adaptive practice, and gamified progression so that users can
+train kanji recognition, vocabulary usage, listening, and pronunciation.
+
+## Project Goals
+
+* **Activate existing knowledge:** Help fans convert words and phrases they have heard
+  repeatedly in VOSTFR/VOSTEN media into usable Japanese.
+* **Personalized learning:** AI agents evaluate answers, provide hints, and adjust
+  difficulty based on user performance and declared manga preferences.
+* **Cross‑platform availability:** Responsive web app (desktop & mobile) with a cloud
+  backend scalable from a single VPS to Kubernetes.
+
+## High‑Level Architecture
+
+| Layer      | Technology (initial suggestion)                                |
+| ---------- | -------------------------------------------------------------- |
+| Frontend   | Vue 3 + TypeScript + Vite, PWA, Web Speech API                 |
+| Backend    | Rust (Axum or Actix‑web), GraphQL/REST APIs                    |
+| Database   | PostgreSQL (core data) + Redis (sessions/cache)                |
+| AI Service | OpenAI or compatible LLMs wrapped by a dedicated microservice  |
+| Container  | Docker for dev/prod parity, deployable to K8s or bare VPS      |
+
+## Core Modules
+
+1. **Flashcard Engine** – spaced repetition, kanji & vocabulary decks, audio playback.
+2. **AI Evaluation** – natural‑language feedback, hint generation, difficulty tuning.
+3. **Speech & Audio** – TTS for sentences, optional pre‑recorded kanji readings,
+   speech recognition for user answers.
+4. **Progress & Gamification** – XP, levels, streaks, achievements, daily quests.
+5. **Content Pipeline** – onboarding questionnaire, per‑user context store, manga
+   references used as thematic anchors for vocabulary.
+
+## Repository Layout (planned)
+
+```
+LearnWithManga/
+├── backend/        # Rust API services
+├── frontend/       # Vue application
+├── infra/          # Docker, CI/CD, deployment manifests
+├── docs/           # Architecture notes and design decisions
+└── TODO.md         # Feature roadmap and task breakdown
+```
+
+## Contributing
+
+The project is at the planning stage. See `TODO.md` for the current roadmap.
+Feel free to suggest improvements or alternative approaches.
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,58 @@
+# TODO / Roadmap
+
+This document breaks down the development plan for **LearnWithManga**. Tasks are grouped
+by feature to allow different contributors and AIs to work in parallel.
+
+## 1. Project Scaffolding
+- [ ] Create `frontend/` (Vue 3 + TypeScript) and `backend/` (Rust) workspaces.
+- [ ] Add `docker-compose.yml` for local development.
+- [ ] Set up CI workflow (GitHub Actions) running lint/tests for both layers.
+- [ ] Configure shared formatting tools: Prettier (frontend) & rustfmt/clippy (backend).
+
+## 2. User Management & Onboarding
+- [ ] Implement registration/login with JWT auth and password hashing.
+- [ ] Store user profile (preferred manga series, known vocabulary, consent flags).
+- [ ] Build onboarding questionnaire to collect initial manga knowledge.
+- [ ] API endpoint to update user context after each session.
+
+## 3. Flashcard Engine
+- [ ] Design database schema for decks, cards, user progress, and scheduling.
+- [ ] CRUD endpoints for cards and decks (admin/internal usage).
+- [ ] Implement spaced‑repetition scheduler (SM‑2 variant or custom algorithm).
+- [ ] Frontend card viewer supporting text, kanji, and audio playback.
+- [ ] Allow users to answer via typing or voice; send results to AI evaluator.
+
+## 4. AI Evaluation & Hint System
+- [ ] Create microservice wrapping LLM API calls with per‑user context.
+- [ ] Define prompt templates for answer checking and hint generation.
+- [ ] Support hint tiers (e.g., first hint about radicals, second hint example word).
+- [ ] Log AI interactions for analytics and future model tuning.
+
+## 5. Audio & Speech Features
+- [ ] Integrate TTS for sentence cards (cloud provider or open‑source models).
+- [ ] Maintain library of pre‑recorded kanji readings for accuracy.
+- [ ] Use Web Speech API (browser) and/or server‑side recognition for pronunciation
+      evaluation.
+- [ ] Provide playback controls and waveform display for recorded answers.
+
+## 6. Progress Tracking & Gamification
+- [ ] XP system tied to card difficulty and session streaks.
+- [ ] Level tiers unlocking new manga‑themed quests or sentence translation mode.
+- [ ] Achievement badges for milestones (e.g., "100 kanji mastered").
+- [ ] Dashboard summarizing stats: accuracy, retention, favorite series, etc.
+
+## 7. Deployment & Infrastructure
+- [ ] Write production Dockerfiles for frontend and backend.
+- [ ] Provision PostgreSQL & Redis instances via Docker or cloud services.
+- [ ] Helm charts or Terraform modules for future Kubernetes/AWS deployment.
+- [ ] Monitoring stack (Prometheus + Grafana) and log aggregation.
+
+## 8. Future Enhancements
+- [ ] Sentence translation challenges for advanced users.
+- [ ] Community features: optional leaderboards, shared decks, manga discussion.
+- [ ] Mobile app wrapper using Capacitor or React Native.
+- [ ] Monetization layer (subscriptions, API usage metering).
+- [ ] Data export/import compatible with Anki.
+
+---
+This roadmap is a living document. Update tasks as features evolve or new ideas emerge.


### PR DESCRIPTION
## Summary
- document LearnWithManga's goals and architecture in a new README
- add detailed TODO roadmap for project scaffolding, features, and deployment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac31f28a30832ea241babfe8ee583f