### PR TITLE
feat: migrate cards/decks from Supabase to JSON catalog system

### DIFF
--- a/backend/migrations/20260523000009_drop_content_tables.sql
+++ b/backend/migrations/20260523000009_drop_content_tables.sql
@@ -1,0 +1,5 @@
+-- Drop content tables (replaced by JSON catalog in data/)
+-- Order matters due to foreign key constraints
+DROP TABLE IF EXISTS user_card_progress;
+DROP TABLE IF EXISTS cards;
+DROP TABLE IF EXISTS decks;

--- a/backend/src/catalog.rs
+++ b/backend/src/catalog.rs
@@ -1,0 +1,255 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Card {
+    pub id: String,
+    pub kanji: String,
+    pub romaji: String,
+    pub fr: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeckCardLink {
+    pub card_id: String,
+    pub anime_reference: Option<String>,
+    pub context_sentence: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Deck {
+    pub slug: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub cards: Vec<DeckCardLink>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CardsFile {
+    cards: Vec<Card>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DeckFile {
+    deck: Deck,
+}
+
+#[derive(Debug, Clone)]
+pub struct CardCatalog {
+    pub cards: HashMap<String, Card>,
+    pub decks: HashMap<String, Deck>,
+}
+
+#[derive(Debug)]
+pub enum LoadError {
+    Io(String),
+    DuplicateCardId {
+        id: String,
+        file1: String,
+        file2: String,
+    },
+    DuplicateDeckSlug {
+        slug: String,
+        file1: String,
+        file2: String,
+    },
+    UnresolvedCardRef {
+        deck_slug: String,
+        card_id: String,
+    },
+    InvalidSlug {
+        slug: String,
+        kind: &'static str,
+    },
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoadError::Io(msg) => write!(f, "IO error: {}", msg),
+            LoadError::DuplicateCardId { id, file1, file2 } => {
+                write!(
+                    f,
+                    "Duplicate card id '{}' in files '{}' and '{}'",
+                    id, file1, file2
+                )
+            }
+            LoadError::DuplicateDeckSlug { slug, file1, file2 } => {
+                write!(
+                    f,
+                    "Duplicate deck slug '{}' in files '{}' and '{}'",
+                    slug, file1, file2
+                )
+            }
+            LoadError::UnresolvedCardRef { deck_slug, card_id } => {
+                write!(
+                    f,
+                    "Deck '{}' references card_id '{}' which does not exist in any cards file",
+                    deck_slug, card_id
+                )
+            }
+            LoadError::InvalidSlug { slug, kind } => {
+                write!(
+                    f,
+                    "Invalid {} slug '{}': must be lowercase with hyphens only",
+                    kind, slug
+                )
+            }
+        }
+    }
+}
+
+fn validate_slug(slug: &str) -> bool {
+    if slug.is_empty() {
+        return false;
+    }
+    slug.chars().all(|c| c.is_ascii_lowercase() || c == '-')
+}
+
+fn load_json_files<T: for<'de> serde::Deserialize<'de>>(
+    dir: &Path,
+) -> Result<Vec<(String, T)>, LoadError> {
+    let mut results = Vec::new();
+    let entries = fs::read_dir(dir)
+        .map_err(|e| LoadError::Io(format!("Cannot read directory {}: {}", dir.display(), e)))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| LoadError::Io(e.to_string()))?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            let content = fs::read_to_string(&path)
+                .map_err(|e| LoadError::Io(format!("Cannot read {}: {}", path.display(), e)))?;
+            let parsed: T = serde_json::from_str(&content).map_err(|e| {
+                LoadError::Io(format!("JSON parse error in {}: {}", path.display(), e))
+            })?;
+            let fname = path.file_name().unwrap().to_string_lossy().to_string();
+            results.push((fname, parsed));
+        }
+    }
+
+    Ok(results)
+}
+
+pub fn load_catalog(data_dir: &Path) -> Result<CardCatalog, LoadError> {
+    let cards_dir = data_dir.join("cards");
+    let decks_dir = data_dir.join("decks");
+
+    // Load all cards
+    let mut cards_map: HashMap<String, (String, Card)> = HashMap::new();
+    let cards_files = load_json_files::<CardsFile>(&cards_dir)?;
+
+    for (fname, cards_file) in &cards_files {
+        for card in &cards_file.cards {
+            if !validate_slug(&card.id) {
+                return Err(LoadError::InvalidSlug {
+                    slug: card.id.clone(),
+                    kind: "card",
+                });
+            }
+            if let Some((existing_file, _)) = cards_map.get(&card.id) {
+                return Err(LoadError::DuplicateCardId {
+                    id: card.id.clone(),
+                    file1: existing_file.clone(),
+                    file2: fname.clone(),
+                });
+            }
+            cards_map.insert(card.id.clone(), (fname.clone(), card.clone()));
+        }
+    }
+
+    let cards: HashMap<String, Card> = cards_map
+        .into_values()
+        .map(|(_, card)| (card.id.clone(), card))
+        .collect();
+
+    // Load all decks
+    let mut decks_map: HashMap<String, (String, Deck)> = HashMap::new();
+    let deck_files = load_json_files::<DeckFile>(&decks_dir)?;
+
+    for (fname, deck_file) in &deck_files {
+        let deck = &deck_file.deck;
+
+        if !validate_slug(&deck.slug) {
+            return Err(LoadError::InvalidSlug {
+                slug: deck.slug.clone(),
+                kind: "deck",
+            });
+        }
+
+        if let Some((existing_file, _)) = decks_map.get(&deck.slug) {
+            return Err(LoadError::DuplicateDeckSlug {
+                slug: deck.slug.clone(),
+                file1: existing_file.clone(),
+                file2: fname.clone(),
+            });
+        }
+
+        // Validate all card references
+        for link in &deck.cards {
+            if !cards.contains_key(&link.card_id) {
+                return Err(LoadError::UnresolvedCardRef {
+                    deck_slug: deck.slug.clone(),
+                    card_id: link.card_id.clone(),
+                });
+            }
+        }
+
+        decks_map.insert(deck.slug.clone(), (fname.clone(), deck.clone()));
+    }
+
+    let decks: HashMap<String, Deck> = decks_map
+        .into_values()
+        .map(|(_, deck)| (deck.slug.clone(), deck))
+        .collect();
+
+    Ok(CardCatalog { cards, decks })
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HydratedDeckCard {
+    pub card_id: String,
+    pub kanji: String,
+    pub romaji: String,
+    pub fr: String,
+    pub anime_reference: Option<String>,
+    pub context_sentence: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HydratedDeck {
+    pub slug: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub cards: Vec<HydratedDeckCard>,
+}
+
+impl HydratedDeck {
+    pub fn from_deck(deck: &Deck, catalog: &CardCatalog) -> Self {
+        let cards = deck
+            .cards
+            .iter()
+            .filter_map(|link| {
+                catalog
+                    .cards
+                    .get(&link.card_id)
+                    .map(|card| HydratedDeckCard {
+                        card_id: link.card_id.clone(),
+                        kanji: card.kanji.clone(),
+                        romaji: card.romaji.clone(),
+                        fr: card.fr.clone(),
+                        anime_reference: link.anime_reference.clone(),
+                        context_sentence: link.context_sentence.clone(),
+                    })
+            })
+            .collect();
+
+        HydratedDeck {
+            slug: deck.slug.clone(),
+            name: deck.name.clone(),
+            description: deck.description.clone(),
+            cards,
+        }
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,5 @@
 mod ai;
+mod catalog;
 mod db;
 
 use ai::{EvaluateRequest, HintRequest, LlmClient, ModelsRequest};
@@ -11,30 +12,14 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 
 struct AppState {
     llm_client: LlmClient,
     db_pool: sqlx::PgPool,
-}
-
-#[derive(Debug, Serialize, sqlx::FromRow)]
-struct Deck {
-    id: uuid::Uuid,
-    name: String,
-    description: Option<String>,
-}
-
-#[derive(Debug, Serialize, sqlx::FromRow)]
-struct Card {
-    id: uuid::Uuid,
-    deck_id: uuid::Uuid,
-    vocab: String,
-    reading: Option<String>,
-    french_translation: String,
-    anime_reference: Option<String>,
-    context_sentence: Option<String>,
+    catalog: catalog::CardCatalog,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -117,9 +102,21 @@ async fn main() {
     }
 
     let llm_client = LlmClient::new();
+
+    let data_dir = env::var("DATA_DIR").unwrap_or_else(|_| "../data".to_string());
+    let catalog = catalog::load_catalog(&PathBuf::from(&data_dir)).unwrap_or_else(|e| {
+        panic!("❌ Erreur chargement catalogue: {}", e);
+    });
+    println!(
+        "📚 Catalogue chargé: {} cartes, {} decks",
+        catalog.cards.len(),
+        catalog.decks.len()
+    );
+
     let shared_state = Arc::new(AppState {
         llm_client,
         db_pool,
+        catalog,
     });
 
     // Configuration des CORS pour autoriser le frontend (port 5173 ou autre)
@@ -133,11 +130,9 @@ async fn main() {
         .route("/api/ai/evaluate", post(handle_evaluate))
         .route("/api/ai/hint", post(handle_hint))
         .route("/api/ai/models", post(handle_get_models))
-        // Routes Base de Données
-        .route("/api/db/seed", post(handle_seed_db))
+        // Routes Catalogue (JSON)
         .route("/api/decks", get(handle_get_decks))
-        .route("/api/cards", get(handle_get_all_cards))
-        .route("/api/decks/:id/cards", get(handle_get_deck_cards))
+        .route("/api/decks/:slug", get(handle_get_deck_by_slug))
         .route(
             "/api/user/llm-settings/:user_id",
             get(handle_get_user_settings),
@@ -672,160 +667,48 @@ async fn handle_link_admin(
 }
 
 // ==========================================
-// Handlers Base de Données
+// Handlers Catalogue (JSON)
 // ==========================================
 
-/// Seeder la base de données avec nos exemples favoris
-async fn handle_seed_db(
-    State(state): State<Arc<AppState>>,
-) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    println!("📥 Requête de seeding de la base de données");
-
-    // Vérifie s'il y a déjà des paquets en base
-    let deck_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM decks")
-        .fetch_one(&state.db_pool)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Erreur comptage decks: {}", e),
-            )
-        })?;
-
-    if deck_count > 0 {
-        println!("ℹ️ La base de données contient déjà des decks. Seeding annulé.");
-        return Ok(Json(serde_json::json!({
-            "status": "success",
-            "message": "La base de données est déjà initialisée."
-        })));
-    }
-
-    // Crée le premier deck
-    let deck_id = uuid::Uuid::new_v4();
-    sqlx::query(
-        "INSERT INTO decks (id, name, description) VALUES ($1, $2, $3)"
-    )
-    .bind(deck_id)
-    .bind("Animés Légendaires")
-    .bind("Un paquet contenant les expressions cultes et mots clés issus de vos mangas et animés préférés.")
-    .execute(&state.db_pool)
-    .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Échec création deck: {}", e)))?;
-
-    // Insère nos 4 mots phares
-    let seed_cards = vec![
-        (
-            "諦める",
-            "あきらめる",
-            "renoncer / abandonner",
-            "Général / Commun",
-            "Ce verbe est couramment utilisé dans les animés lors des moments dramatiques, souvent sous la forme de négation (諦めるな - Akirameruna - N'abandonne pas !)",
-        ),
-        (
-            "お前はもう死んでいる",
-            "おまえはもうしんでいる",
-            "tu es déjà mort",
-            "Hokuto no Ken",
-            "La réplique mythique de Kenshiro juste avant l'explosion de son adversaire.",
-        ),
-        (
-            "心臓を捧げよ",
-            "しんぞうをささげよ",
-            "offrez vos cœurs / dédiez vos cœurs",
-            "Shingeki no Kyojin",
-            "Le cri de ralliement emblématique du Bataillon d'exploration mené par Erwin Smith.",
-        ),
-        (
-            "螺旋丸",
-            "らせんがん",
-            "l'orbe tourbillonnant",
-            "Naruto",
-            "Une technique ninja surpuissante créée par Minato Namikaze et perfectionnée par Naruto Uzumaki.",
-        ),
-    ];
-
-    let mut inserted_count = 0;
-    for (vocab, reading, french, anime, context) in seed_cards {
-        sqlx::query(
-            "INSERT INTO cards (id, deck_id, vocab, reading, french_translation, anime_reference, context_sentence) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7)"
-        )
-        .bind(uuid::Uuid::new_v4())
-        .bind(deck_id)
-        .bind(vocab)
-        .bind(reading)
-        .bind(french)
-        .bind(anime)
-        .bind(context)
-        .execute(&state.db_pool)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Échec insertion carte {}: {}", vocab, e)))?;
-
-        inserted_count += 1;
-    }
-
-    println!("✅ Seeding complété ! {} cartes insérées.", inserted_count);
-    Ok(Json(serde_json::json!({
-        "status": "success",
-        "message": format!("Base de données initialisée avec {} cartes dans le deck 'Animés Légendaires'.", inserted_count)
-    })))
-}
-
-/// Récupérer tous les Decks
+/// Récupérer tous les Decks (métadonnées seulement)
 async fn handle_get_decks(
     State(state): State<Arc<AppState>>,
-) -> Result<Json<Vec<Deck>>, (StatusCode, String)> {
-    println!("📥 Récupération des paquets de cartes");
-
-    let decks = sqlx::query_as::<_, Deck>("SELECT id, name, description FROM decks ORDER BY name")
-        .fetch_all(&state.db_pool)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Impossible de charger les decks: {}", e),
-            )
-        })?;
-
+) -> Result<Json<Vec<DeckMeta>>, (StatusCode, String)> {
+    let mut decks: Vec<DeckMeta> = state
+        .catalog
+        .decks
+        .values()
+        .map(|d| DeckMeta {
+            slug: d.slug.clone(),
+            name: d.name.clone(),
+            description: d.description.clone(),
+            card_count: d.cards.len(),
+        })
+        .collect();
+    decks.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(Json(decks))
 }
 
-/// Récupérer toutes les cartes
-async fn handle_get_all_cards(
+/// Récupérer un deck avec ses cartes hydratées
+async fn handle_get_deck_by_slug(
     State(state): State<Arc<AppState>>,
-) -> Result<Json<Vec<Card>>, (StatusCode, String)> {
-    println!("📥 Récupération de l'intégralité des cartes");
-
-    let cards = sqlx::query_as::<_, Card>(
-        "SELECT id, deck_id, vocab, reading, french_translation, anime_reference, context_sentence FROM cards"
-    )
-    .fetch_all(&state.db_pool)
-    .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Impossible de charger les cartes: {}", e)))?;
-
-    Ok(Json(cards))
-}
-
-/// Récupérer les cartes d'un deck précis
-async fn handle_get_deck_cards(
-    State(state): State<Arc<AppState>>,
-    Path(deck_id): Path<uuid::Uuid>,
-) -> Result<Json<Vec<Card>>, (StatusCode, String)> {
-    println!("📥 Récupération des cartes pour le deck: {}", deck_id);
-
-    let cards = sqlx::query_as::<_, Card>(
-        "SELECT id, deck_id, vocab, reading, french_translation, anime_reference, context_sentence \
-         FROM cards WHERE deck_id = $1",
-    )
-    .bind(deck_id)
-    .fetch_all(&state.db_pool)
-    .await
-    .map_err(|e| {
+    Path(slug): Path<String>,
+) -> Result<Json<catalog::HydratedDeck>, (StatusCode, String)> {
+    let deck = state.catalog.decks.get(&slug).ok_or_else(|| {
         (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Impossible de charger les cartes du deck: {}", e),
+            StatusCode::NOT_FOUND,
+            format!("Deck '{}' introuvable", slug),
         )
     })?;
 
-    Ok(Json(cards))
+    let hydrated = catalog::HydratedDeck::from_deck(deck, &state.catalog);
+    Ok(Json(hydrated))
+}
+
+#[derive(Debug, Serialize)]
+struct DeckMeta {
+    slug: String,
+    name: String,
+    description: Option<String>,
+    card_count: usize,
 }

--- a/data/cards/common.json
+++ b/data/cards/common.json
@@ -1,0 +1,28 @@
+{
+  "cards": [
+    {
+      "id": "tomodachi",
+      "kanji": "友達",
+      "romaji": "tomodachi",
+      "fr": "amis"
+    },
+    {
+      "id": "nakama",
+      "kanji": "仲間",
+      "romaji": "nakama",
+      "fr": "camarade / équipier"
+    },
+    {
+      "id": "sensei",
+      "kanji": "先生",
+      "romaji": "sensei",
+      "fr": "professeur / maître"
+    },
+    {
+      "id": "kakkoi",
+      "kanji": "格好いい",
+      "romaji": "kakkoi",
+      "fr": "cool / beau"
+    }
+  ]
+}

--- a/data/cards/naruto.json
+++ b/data/cards/naruto.json
@@ -1,0 +1,28 @@
+{
+  "cards": [
+    {
+      "id": "rasengan",
+      "kanji": "螺旋丸",
+      "romaji": "rasengan",
+      "fr": "orbe tourbillonnant"
+    },
+    {
+      "id": "shinobi",
+      "kanji": "忍",
+      "romaji": "shinobi",
+      "fr": "ninja"
+    },
+    {
+      "id": "katon",
+      "kanji": "火遁",
+      "romaji": "katon",
+      "fr": "technique de feu"
+    },
+    {
+      "id": "akirameru",
+      "kanji": "諦める",
+      "romaji": "akirameru",
+      "fr": "renoncer / abandonner"
+    }
+  ]
+}

--- a/data/decks/naruto.json
+++ b/data/decks/naruto.json
@@ -1,0 +1,44 @@
+{
+  "deck": {
+    "slug": "naruto",
+    "name": "Naruto",
+    "description": "Vocabulaire tiré de l'univers Naruto"
+  },
+  "cards": [
+    {
+      "card_id": "rasengan",
+      "anime_reference": "Naruto EP01",
+      "context_sentence": "ナルトの螺旋丸は最強の技だ。"
+    },
+    {
+      "card_id": "shinobi",
+      "anime_reference": "Naruto EP01",
+      "context_sentence": "忍の世界へようこそ！"
+    },
+    {
+      "card_id": "katon",
+      "anime_reference": "Naruto EP101",
+      "context_sentence": "サスケが火遁の術を使った。"
+    },
+    {
+      "card_id": "akirameru",
+      "anime_reference": "Naruto EP133",
+      "context_sentence": "ナルトは決して諦めない！"
+    },
+    {
+      "card_id": "tomodachi",
+      "anime_reference": "Naruto EP01",
+      "context_sentence": "サスケはナルトの大事な友達だ。"
+    },
+    {
+      "card_id": "nakama",
+      "anime_reference": "Naruto EP02",
+      "context_sentence": "仲間を守るのが忍の道だ。"
+    },
+    {
+      "card_id": "sensei",
+      "anime_reference": "Naruto EP03",
+      "context_sentence": "イルカ先生は優しい。"
+    }
+  ]
+}

--- a/data/decks/shingeki.json
+++ b/data/decks/shingeki.json
@@ -1,0 +1,24 @@
+{
+  "deck": {
+    "slug": "shingeki",
+    "name": "Shingeki no Kyojin",
+    "description": "Vocabulaire de l'Attaque des Titans"
+  },
+  "cards": [
+    {
+      "card_id": "tomodachi",
+      "anime_reference": "Shingeki S01E01",
+      "context_sentence": "エレンとアルミンは幼い頃からの友達だ。"
+    },
+    {
+      "card_id": "nakama",
+      "anime_reference": "Shingeki S02E06",
+      "context_sentence": "お前ら、仲間を信じろ！"
+    },
+    {
+      "card_id": "sensei",
+      "anime_reference": "Shingeki S01E02",
+      "context_sentence": "シャディス先生は厳しい。"
+    }
+  ]
+}

--- a/frontend/src/services/cards.ts
+++ b/frontend/src/services/cards.ts
@@ -1,26 +1,44 @@
 import { API_BASE, PresetItem } from './api'
 
-export async function fetchCards(): Promise<{
-  presets: PresetItem[]
-  isSeeded: boolean
-}> {
-  const response = await fetch(`${API_BASE}/cards`)
-  if (!response.ok) throw new Error('Failed to fetch cards')
-  const data = await response.json()
-  const presets: PresetItem[] = data.map((c: any) => ({
-    vocab: c.vocab,
-    anime: c.anime_reference || 'Général',
-    defaultAnswer: c.french_translation,
-  }))
-  return { presets, isSeeded: presets.length > 0 }
+export interface DeckMeta {
+  slug: string
+  name: string
+  description: string | null
+  card_count: number
 }
 
-export async function seedDatabase(): Promise<void> {
-  const response = await fetch(`${API_BASE}/db/seed`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-  })
-  if (!response.ok) {
-    throw new Error(`Erreur serveur (${response.status})`)
-  }
+export interface HydratedCard {
+  card_id: string
+  kanji: string
+  romaji: string
+  fr: string
+  anime_reference: string | null
+  context_sentence: string | null
+}
+
+export interface HydratedDeck {
+  slug: string
+  name: string
+  description: string | null
+  cards: HydratedCard[]
+}
+
+export async function fetchDecks(): Promise<DeckMeta[]> {
+  const res = await fetch(`${API_BASE}/decks`)
+  if (!res.ok) throw new Error(`Erreur serveur (${res.status})`)
+  return res.json()
+}
+
+export async function fetchDeckBySlug(slug: string): Promise<HydratedDeck> {
+  const res = await fetch(`${API_BASE}/decks/${slug}`)
+  if (!res.ok) throw new Error(`Erreur serveur (${res.status})`)
+  return res.json()
+}
+
+export function deckCardsAsPresets(deck: HydratedDeck): PresetItem[] {
+  return deck.cards.map((c) => ({
+    vocab: c.kanji,
+    anime: c.anime_reference || deck.name,
+    defaultAnswer: c.fr,
+  }))
 }

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -7,39 +7,30 @@
           <h2>Choisissez un défi japonais</h2>
         </div>
 
-        <div class="preset-selector">
-          <div class="preset-header-inline">
-            <label class="section-label"
-              >Sélection depuis la base de données :</label
-            >
-            <button
-              v-if="!isSeeded"
-              @click="handleSeed"
-              class="seed-btn"
-              :disabled="loadingCards"
-              title="Initialiser la base PostgreSQL/Supabase avec nos exemples cultes"
-            >
-              🌱 Remplir la BDD
-            </button>
-          </div>
-
+        <div class="deck-selector">
+          <label class="section-label"
+            >Sélectionnez un deck d'apprentissage :</label
+          >
           <div v-if="loadingCards" class="presets-loader">
             <span class="spinner"></span>
-            <span>Chargement des cartes depuis la base...</span>
+            <span>Chargement des decks...</span>
           </div>
-
-          <div v-else-if="presets.length === 0" class="empty-presets-alert">
-            <p>La base de données est connectée mais vide.</p>
+          <div v-else class="deck-buttons">
             <button
-              @click="handleSeed"
-              class="btn btn-secondary btn-sm"
-              style="margin-top: 10px"
+              v-for="deck in decks"
+              :key="deck.slug"
+              @click="selectDeck(deck.slug)"
+              :class="['deck-btn', { active: selectedDeckSlug === deck.slug }]"
             >
-              🌱 Charger le deck 'Animés Légendaires'
+              <div class="deck-name">{{ deck.name }}</div>
+              <div class="deck-meta">{{ deck.card_count }} cartes</div>
             </button>
           </div>
+        </div>
 
-          <div v-else class="presets-grid">
+        <div v-if="presets.length > 0" class="preset-selector">
+          <label class="section-label">Choisissez une carte du deck :</label>
+          <div class="presets-grid">
             <button
               v-for="item in presets"
               :key="item.vocab"
@@ -222,7 +213,12 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
 import { PresetItem, EvalData } from '../services/api'
-import { fetchCards, seedDatabase } from '../services/cards'
+import {
+  fetchDecks,
+  fetchDeckBySlug,
+  deckCardsAsPresets,
+} from '../services/cards'
+import type { DeckMeta } from '../services/cards'
 import { fetchHint, evaluateAnswer } from '../services/llm'
 
 const props = defineProps<{
@@ -236,9 +232,10 @@ const props = defineProps<{
   frequencyPenalty: number
 }>()
 
+const decks = ref<DeckMeta[]>([])
+const selectedDeckSlug = ref('')
 const presets = ref<PresetItem[]>([])
 const loadingCards = ref(false)
-const isSeeded = ref(false)
 
 const currentVocab = ref('')
 const currentAnime = ref('')
@@ -280,33 +277,30 @@ function toggleCustom() {
   isCustom.value = !isCustom.value
 }
 
-async function loadCards() {
+async function loadDecks() {
   loadingCards.value = true
   try {
-    const result = await fetchCards()
-    presets.value = result.presets
-    isSeeded.value = result.isSeeded
-    if (result.isSeeded && !currentVocab.value) {
-      currentVocab.value = result.presets[0].vocab
-      currentAnime.value = result.presets[0].anime
-    }
+    decks.value = await fetchDecks()
   } catch {
-    isSeeded.value = false
+    decks.value = []
   } finally {
     loadingCards.value = false
   }
 }
 
-async function handleSeed() {
-  loadingCards.value = true
-  errorMessage.value = ''
+async function selectDeck(slug: string) {
+  selectedDeckSlug.value = slug
+  presets.value = []
+  currentVocab.value = ''
+  currentAnime.value = ''
   try {
-    await seedDatabase()
-    await loadCards()
+    const deck = await fetchDeckBySlug(slug)
+    presets.value = deckCardsAsPresets(deck)
+    if (presets.value.length > 0) {
+      selectPreset(presets.value[0])
+    }
   } catch (err: any) {
-    errorMessage.value = `Impossible d'initialiser la base de données : ${err.message}.`
-  } finally {
-    loadingCards.value = false
+    errorMessage.value = `Impossible de charger le deck : ${err.message}.`
   }
 }
 
@@ -379,7 +373,7 @@ function getScoreClass(score: number) {
 }
 
 onMounted(() => {
-  loadCards()
+  loadDecks()
 })
 </script>
 
@@ -445,30 +439,6 @@ onMounted(() => {
   margin: 0;
 }
 
-.preset-header-inline {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 12px;
-  gap: 8px;
-}
-.seed-btn {
-  background: rgba(16, 185, 129, 0.12);
-  border: 1px solid rgba(16, 185, 129, 0.3);
-  color: var(--accent);
-  border-radius: 20px;
-  padding: 4px 12px;
-  font-size: 0.8rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  outline: none;
-}
-.seed-btn:hover:not(:disabled) {
-  background: rgba(16, 185, 129, 0.22);
-  border-color: var(--accent);
-  transform: translateY(-1px);
-}
 .presets-loader {
   font-size: 0.95rem;
   color: var(--text-muted);
@@ -480,15 +450,6 @@ onMounted(() => {
   border-radius: 16px;
   justify-content: center;
   border: 1px solid var(--glass-border);
-}
-.empty-presets-alert {
-  font-size: 0.95rem;
-  color: var(--text-muted);
-  border: 1px dashed rgba(255, 255, 255, 0.1);
-  padding: 24px;
-  border-radius: 16px;
-  text-align: center;
-  background: rgba(0, 0, 0, 0.1);
 }
 .presets-grid {
   display: grid;


### PR DESCRIPTION
- Add catalog.rs module with CardCatalog, loader, hydration, validation
- Load catalog from data/ directory at boot, panic on invalid data
- New routes: GET /api/decks (lightweight metadata), GET /api/decks/:slug
- Remove old DB seed/cards/deck-cards endpoints
- Update frontend: deck selector then card picker flow
- Drop old content tables via migration