### PR TITLE
feat: kanji dictionary view with radical explorer and navigation tabs

### DIFF
--- a/backend/src/catalog.rs
+++ b/backend/src/catalog.rs
@@ -32,14 +32,48 @@ struct CardsFile {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+struct DeckFileMeta {
+    slug: String,
+    name: String,
+    description: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 struct DeckFile {
-    deck: Deck,
+    deck: DeckFileMeta,
+    cards: Vec<DeckCardLink>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KanjiEntry {
+    pub char: String,
+    pub on_yomi: Vec<String>,
+    pub kun_yomi: Vec<String>,
+    pub meanings_en: Vec<String>,
+    pub components: Vec<String>,
+    pub stroke_count: Option<u8>,
+    pub frequency_rank: Option<u32>,
+    pub jlpt_level: u8,
+    pub grade: Option<u8>,
+    pub radical_number: Option<u8>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Radical {
+    pub number: u8,
+    pub char: String,
+    pub meaning: String,
+    pub stroke_count: u8,
+    #[serde(default)]
+    pub variants: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct CardCatalog {
     pub cards: HashMap<String, Card>,
     pub decks: HashMap<String, Deck>,
+    pub kanji: HashMap<String, KanjiEntry>,
+    pub radicals: HashMap<u8, Radical>,
 }
 
 #[derive(Debug)]
@@ -135,6 +169,8 @@ fn load_json_files<T: for<'de> serde::Deserialize<'de>>(
 pub fn load_catalog(data_dir: &Path) -> Result<CardCatalog, LoadError> {
     let cards_dir = data_dir.join("cards");
     let decks_dir = data_dir.join("decks");
+    let kanji_dir = data_dir.join("kanji");
+    let radicals_path = data_dir.join("radicals").join("kangxi.json");
 
     // Load all cards
     let mut cards_map: HashMap<String, (String, Card)> = HashMap::new();
@@ -169,7 +205,12 @@ pub fn load_catalog(data_dir: &Path) -> Result<CardCatalog, LoadError> {
     let deck_files = load_json_files::<DeckFile>(&decks_dir)?;
 
     for (fname, deck_file) in &deck_files {
-        let deck = &deck_file.deck;
+        let deck = Deck {
+            slug: deck_file.deck.slug.clone(),
+            name: deck_file.deck.name.clone(),
+            description: deck_file.deck.description.clone(),
+            cards: deck_file.cards.clone(),
+        };
 
         if !validate_slug(&deck.slug) {
             return Err(LoadError::InvalidSlug {
@@ -196,7 +237,7 @@ pub fn load_catalog(data_dir: &Path) -> Result<CardCatalog, LoadError> {
             }
         }
 
-        decks_map.insert(deck.slug.clone(), (fname.clone(), deck.clone()));
+        decks_map.insert(deck.slug.clone(), (fname.clone(), deck));
     }
 
     let decks: HashMap<String, Deck> = decks_map
@@ -204,7 +245,60 @@ pub fn load_catalog(data_dir: &Path) -> Result<CardCatalog, LoadError> {
         .map(|(_, deck)| (deck.slug.clone(), deck))
         .collect();
 
-    Ok(CardCatalog { cards, decks })
+    // Load kanji from JSONL files
+    let mut kanji: HashMap<String, KanjiEntry> = HashMap::new();
+    if kanji_dir.exists() {
+        let entries = fs::read_dir(&kanji_dir)
+            .map_err(|e| LoadError::Io(format!("Cannot read kanji dir: {}", e)))?;
+        for entry in entries {
+            let entry = entry.map_err(|e| LoadError::Io(e.to_string()))?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let content = fs::read_to_string(&path)
+                .map_err(|e| LoadError::Io(format!("Cannot read {}: {}", path.display(), e)))?;
+            for (line_num, line) in content.lines().enumerate() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let k: KanjiEntry = serde_json::from_str(line).map_err(|e| {
+                    LoadError::Io(format!(
+                        "JSONL parse error in {} line {}: {}",
+                        path.display(),
+                        line_num + 1,
+                        e
+                    ))
+                })?;
+                if kanji.contains_key(&k.char) {
+                    return Err(LoadError::Io(format!(
+                        "Duplicate kanji '{}' in JSONL files",
+                        k.char
+                    )));
+                }
+                kanji.insert(k.char.clone(), k);
+            }
+        }
+    }
+
+    // Load radicals
+    let radicals: HashMap<u8, Radical> = if radicals_path.exists() {
+        let content = fs::read_to_string(&radicals_path)
+            .map_err(|e| LoadError::Io(format!("Cannot read kangxi.json: {}", e)))?;
+        let list: Vec<Radical> = serde_json::from_str(&content)
+            .map_err(|e| LoadError::Io(format!("Cannot parse kangxi.json: {}", e)))?;
+        list.into_iter().map(|r| (r.number, r)).collect()
+    } else {
+        HashMap::new()
+    };
+
+    Ok(CardCatalog {
+        cards,
+        decks,
+        kanji,
+        radicals,
+    })
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -108,9 +108,11 @@ async fn main() {
         panic!("❌ Erreur chargement catalogue: {}", e);
     });
     println!(
-        "📚 Catalogue chargé: {} cartes, {} decks",
+        "📚 Catalogue chargé: {} cartes, {} decks, {} kanji, {} radicaux",
         catalog.cards.len(),
-        catalog.decks.len()
+        catalog.decks.len(),
+        catalog.kanji.len(),
+        catalog.radicals.len()
     );
 
     let shared_state = Arc::new(AppState {
@@ -133,6 +135,10 @@ async fn main() {
         // Routes Catalogue (JSON)
         .route("/api/decks", get(handle_get_decks))
         .route("/api/decks/:slug", get(handle_get_deck_by_slug))
+        .route("/api/kanji", get(handle_list_kanji))
+        .route("/api/kanji/:kanji_char", get(handle_get_kanji))
+        .route("/api/radicals", get(handle_list_radicals))
+        .route("/api/radicals/:number", get(handle_get_radical))
         .route(
             "/api/user/llm-settings/:user_id",
             get(handle_get_user_settings),
@@ -711,4 +717,74 @@ struct DeckMeta {
     name: String,
     description: Option<String>,
     card_count: usize,
+}
+
+// ==========================================
+// Handlers Kanji
+// ==========================================
+
+/// Lister tous les kanji (métadonnées légères : char + jlpt_level + radical_number)
+async fn handle_list_kanji(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<KanjiMeta>>, (StatusCode, String)> {
+    let mut list: Vec<KanjiMeta> = state
+        .catalog
+        .kanji
+        .values()
+        .map(|k| KanjiMeta {
+            char: k.char.clone(),
+            jlpt_level: k.jlpt_level,
+            radical_number: k.radical_number,
+            stroke_count: k.stroke_count,
+            frequency_rank: k.frequency_rank,
+        })
+        .collect();
+    list.sort_by_key(|k| k.frequency_rank.unwrap_or(u32::MAX));
+    Ok(Json(list))
+}
+
+/// Récupérer un kanji complet par son caractère
+async fn handle_get_kanji(
+    State(state): State<Arc<AppState>>,
+    Path(kanji_char): Path<String>,
+) -> Result<Json<catalog::KanjiEntry>, (StatusCode, String)> {
+    let k = state.catalog.kanji.get(&kanji_char).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("Kanji '{}' introuvable", kanji_char),
+        )
+    })?;
+    Ok(Json(k.clone()))
+}
+
+/// Lister tous les radicaux
+async fn handle_list_radicals(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<catalog::Radical>>, (StatusCode, String)> {
+    let mut list: Vec<catalog::Radical> = state.catalog.radicals.values().cloned().collect();
+    list.sort_by_key(|r| r.number);
+    Ok(Json(list))
+}
+
+/// Récupérer un radical par son numéro
+async fn handle_get_radical(
+    State(state): State<Arc<AppState>>,
+    Path(number): Path<u8>,
+) -> Result<Json<catalog::Radical>, (StatusCode, String)> {
+    let r = state.catalog.radicals.get(&number).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("Radical {} introuvable", number),
+        )
+    })?;
+    Ok(Json(r.clone()))
+}
+
+#[derive(Debug, Serialize)]
+struct KanjiMeta {
+    char: String,
+    jlpt_level: u8,
+    radical_number: Option<u8>,
+    stroke_count: Option<u8>,
+    frequency_rank: Option<u32>,
 }

--- a/frontend/src/components/AiPlayground.vue
+++ b/frontend/src/components/AiPlayground.vue
@@ -553,7 +553,9 @@ const apiUrl = ref('http://localhost:1337/v1')
 const apiKey = ref('')
 
 // Navigation et validation d'API
-const currentView = ref<'playground' | 'settings' | 'admin' | 'kanji'>('playground')
+const currentView = ref<'playground' | 'settings' | 'admin' | 'kanji'>(
+  'playground',
+)
 const isAdmin = ref(false)
 const isConnectionVerified = ref(false)
 const connectionError = ref('')

--- a/frontend/src/components/AiPlayground.vue
+++ b/frontend/src/components/AiPlayground.vue
@@ -14,6 +14,7 @@
       @activate-config="activateConfig"
       @go-to-settings="currentView = 'settings'"
       @go-to-playground="currentView = 'playground'"
+      @go-to-kanji="currentView = 'kanji'"
       @go-to-admin="currentView = 'admin'"
       @sign-out="handleSignOut"
     />
@@ -442,6 +443,9 @@
       </Transition>
     </div>
 
+    <!-- Vue Kanji -->
+    <KanjiView v-else-if="currentView === 'kanji'" />
+
     <!-- Vue Admin -->
     <div
       v-else-if="currentView === 'admin'"
@@ -459,6 +463,7 @@ import { supabase } from '../supabase'
 import HeaderSection from './HeaderSection.vue'
 import AdminPanel from './AdminPanel.vue'
 import HomeView from '../views/HomeView.vue'
+import KanjiView from '../views/KanjiView.vue'
 import { getApiUrlError } from '../services/api'
 
 interface UserLlmSettings {
@@ -548,7 +553,7 @@ const apiUrl = ref('http://localhost:1337/v1')
 const apiKey = ref('')
 
 // Navigation et validation d'API
-const currentView = ref<'playground' | 'settings' | 'admin'>('playground')
+const currentView = ref<'playground' | 'settings' | 'admin' | 'kanji'>('playground')
 const isAdmin = ref(false)
 const isConnectionVerified = ref(false)
 const connectionError = ref('')
@@ -1097,34 +1102,6 @@ onMounted(() => {
   color: #a78bfa;
   font-weight: 600;
   word-break: break-all;
-}
-
-/* Preset Selector Styles (SQL) */
-.preset-header-inline {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 12px;
-  gap: 8px;
-}
-
-.seed-btn {
-  background: rgba(16, 185, 129, 0.12);
-  border: 1px solid rgba(16, 185, 129, 0.3);
-  color: var(--accent);
-  border-radius: 20px;
-  padding: 4px 12px;
-  font-size: 0.8rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  outline: none;
-}
-
-.seed-btn:hover:not(:disabled) {
-  background: rgba(16, 185, 129, 0.22);
-  border-color: var(--accent);
-  transform: translateY(-1px);
 }
 
 .presets-loader {

--- a/frontend/src/components/HeaderSection.vue
+++ b/frontend/src/components/HeaderSection.vue
@@ -88,7 +88,15 @@
     </div>
     <nav class="nav-tabs">
       <button
-        :class="['nav-tab', { active: currentView === 'playground' || currentView === 'settings' || currentView === 'admin' }]"
+        :class="[
+          'nav-tab',
+          {
+            active:
+              currentView === 'playground' ||
+              currentView === 'settings' ||
+              currentView === 'admin',
+          },
+        ]"
         @click="$emit('go-to-playground')"
       >
         🎴 Playground

--- a/frontend/src/components/HeaderSection.vue
+++ b/frontend/src/components/HeaderSection.vue
@@ -38,7 +38,7 @@
 
         <!-- Bouton Paramètres -->
         <button
-          v-if="currentView === 'playground'"
+          v-if="currentView === 'playground' || currentView === 'kanji'"
           @click="$emit('go-to-settings')"
           class="action-icon-btn btn-settings"
           title="Paramètres de l'IA"
@@ -46,7 +46,7 @@
           ⚙️
         </button>
         <button
-          v-else
+          v-if="currentView === 'settings' || currentView === 'admin'"
           @click="$emit('go-to-playground')"
           class="action-icon-btn btn-settings"
           title="Retour au défi de japonais"
@@ -86,6 +86,20 @@
         </button>
       </div>
     </div>
+    <nav class="nav-tabs">
+      <button
+        :class="['nav-tab', { active: currentView === 'playground' || currentView === 'settings' || currentView === 'admin' }]"
+        @click="$emit('go-to-playground')"
+      >
+        🎴 Playground
+      </button>
+      <button
+        :class="['nav-tab', { active: currentView === 'kanji' }]"
+        @click="$emit('go-to-kanji')"
+      >
+        📖 Dico Kanji
+      </button>
+    </nav>
   </header>
 </template>
 
@@ -112,7 +126,7 @@ defineProps<{
   hasActiveConfig: boolean
   userConfigs: UserLlmSettings[]
   activeConfigName: string
-  currentView: 'playground' | 'settings' | 'admin'
+  currentView: 'playground' | 'settings' | 'admin' | 'kanji'
   isAdmin: boolean
 }>()
 
@@ -121,6 +135,7 @@ const emit = defineEmits<{
   'activate-config': [configName: string]
   'go-to-settings': []
   'go-to-playground': []
+  'go-to-kanji': []
   'go-to-admin': []
   'sign-out': []
 }>()
@@ -349,5 +364,42 @@ const onConfigChange = (event: Event) => {
 .header-config-select option {
   background: #1e293b;
   color: #f1f5f9;
+}
+
+.nav-tabs {
+  display: flex;
+  gap: 4px;
+  max-width: var(--content-max-width);
+  margin: 0 auto;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--glass-border);
+  border-radius: 14px;
+  padding: 4px;
+}
+
+.nav-tab {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+  outline: none;
+}
+
+.nav-tab:hover {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.nav-tab.active {
+  color: white;
+  background: linear-gradient(135deg, #ec4899 0%, #8b5cf6 100%);
+  box-shadow: 0 2px 8px var(--primary-glow);
 }
 </style>

--- a/frontend/src/services/kanji.ts
+++ b/frontend/src/services/kanji.ts
@@ -1,0 +1,48 @@
+import { API_BASE } from './api'
+
+export interface KanjiMeta {
+  char: string
+  jlpt_level: number
+  radical_number: number | null
+  stroke_count: number | null
+  frequency_rank: number | null
+}
+
+export interface KanjiEntry {
+  char: string
+  on_yomi: string[]
+  kun_yomi: string[]
+  meanings_en: string[]
+  components: string[]
+  stroke_count: number | null
+  frequency_rank: number | null
+  jlpt_level: number
+  grade: number | null
+  radical_number: number | null
+}
+
+export interface Radical {
+  number: number
+  char: string
+  meaning: string
+  stroke_count: number
+  variants: string[]
+}
+
+export async function fetchRadicals(): Promise<Radical[]> {
+  const res = await fetch(`${API_BASE}/radicals`)
+  if (!res.ok) throw new Error(`Erreur serveur (${res.status})`)
+  return res.json()
+}
+
+export async function fetchKanjiList(): Promise<KanjiMeta[]> {
+  const res = await fetch(`${API_BASE}/kanji`)
+  if (!res.ok) throw new Error(`Erreur serveur (${res.status})`)
+  return res.json()
+}
+
+export async function fetchKanjiDetail(char: string): Promise<KanjiEntry> {
+  const res = await fetch(`${API_BASE}/kanji/${encodeURIComponent(char)}`)
+  if (!res.ok) throw new Error(`Erreur serveur (${res.status})`)
+  return res.json()
+}

--- a/frontend/src/views/KanjiView.vue
+++ b/frontend/src/views/KanjiView.vue
@@ -51,7 +51,10 @@
     </section>
 
     <section class="detail-section">
-      <div v-if="!selectedRadical && !selectedKanjiChar" class="glass-panel detail-placeholder">
+      <div
+        v-if="!selectedRadical && !selectedKanjiChar"
+        class="glass-panel detail-placeholder"
+      >
         <div class="placeholder-content">
           <span class="placeholder-icon">🔍</span>
           <h3>Sélectionnez un radical</h3>
@@ -61,7 +64,9 @@
 
       <div v-else-if="selectedKanji" class="glass-panel">
         <div class="detail-header">
-          <button @click="selectedKanjiChar = null" class="back-btn">◀ Retour</button>
+          <button @click="selectedKanjiChar = null" class="back-btn">
+            ◀ Retour
+          </button>
         </div>
 
         <div class="kanji-detail">
@@ -76,38 +81,65 @@
             </div>
             <div class="info-card">
               <span class="info-label">Traits</span>
-              <span class="info-value">{{ selectedKanji.stroke_count || '?' }}</span>
+              <span class="info-value">{{
+                selectedKanji.stroke_count || '?'
+              }}</span>
             </div>
             <div class="info-card">
               <span class="info-label">Grade</span>
-              <span class="info-value">{{ selectedKanji.grade ? `第${selectedKanji.grade}` : '—' }}</span>
+              <span class="info-value">{{
+                selectedKanji.grade ? `第${selectedKanji.grade}` : '—'
+              }}</span>
             </div>
             <div class="info-card">
               <span class="info-label">Fréquence</span>
-              <span class="info-value">{{ selectedKanji.frequency_rank ? `#${selectedKanji.frequency_rank}` : '—' }}</span>
+              <span class="info-value">{{
+                selectedKanji.frequency_rank
+                  ? `#${selectedKanji.frequency_rank}`
+                  : '—'
+              }}</span>
             </div>
           </div>
 
           <div class="detail-block">
             <h4>Lecture on'yomi (音読み)</h4>
             <div class="yomi-tags">
-              <span v-for="y in selectedKanji.on_yomi" :key="y" class="yomi-tag on-yomi">{{ y }}</span>
-              <span v-if="selectedKanji.on_yomi.length === 0" class="no-data">—</span>
+              <span
+                v-for="y in selectedKanji.on_yomi"
+                :key="y"
+                class="yomi-tag on-yomi"
+                >{{ y }}</span
+              >
+              <span v-if="selectedKanji.on_yomi.length === 0" class="no-data"
+                >—</span
+              >
             </div>
           </div>
 
           <div class="detail-block">
             <h4>Lecture kun'yomi (訓読み)</h4>
             <div class="yomi-tags">
-              <span v-for="y in selectedKanji.kun_yomi" :key="y" class="yomi-tag kun-yomi">{{ y }}</span>
-              <span v-if="selectedKanji.kun_yomi.length === 0" class="no-data">—</span>
+              <span
+                v-for="y in selectedKanji.kun_yomi"
+                :key="y"
+                class="yomi-tag kun-yomi"
+                >{{ y }}</span
+              >
+              <span v-if="selectedKanji.kun_yomi.length === 0" class="no-data"
+                >—</span
+              >
             </div>
           </div>
 
           <div class="detail-block">
             <h4>Sens (EN)</h4>
             <div class="meanings-list">
-              <span v-for="m in selectedKanji.meanings_en" :key="m" class="meaning-item">{{ m }}</span>
+              <span
+                v-for="m in selectedKanji.meanings_en"
+                :key="m"
+                class="meaning-item"
+                >{{ m }}</span
+              >
             </div>
           </div>
 
@@ -127,10 +159,17 @@
 
           <div class="detail-block">
             <h4>Radical</h4>
-            <div class="radical-ref" @click="goToRadical(selectedKanji.radical_number!)">
+            <div
+              class="radical-ref"
+              @click="goToRadical(selectedKanji.radical_number!)"
+            >
               <span class="rr-char">{{ radicalForCurrentKanji?.char }}</span>
-              <span class="rr-number">Radical {{ selectedKanji.radical_number }}</span>
-              <span class="rr-meaning">{{ radicalForCurrentKanji?.meaning }}</span>
+              <span class="rr-number"
+                >Radical {{ selectedKanji.radical_number }}</span
+              >
+              <span class="rr-meaning">{{
+                radicalForCurrentKanji?.meaning
+              }}</span>
             </div>
           </div>
         </div>
@@ -142,7 +181,10 @@
             <span class="rr-big-char">{{ selectedRadical!.char }}</span>
             <span class="rr-info">
               <strong>{{ selectedRadical!.meaning }}</strong>
-              <span class="rr-meta">Radical {{ selectedRadical!.number }} — {{ selectedRadical!.stroke_count }} traits</span>
+              <span class="rr-meta"
+                >Radical {{ selectedRadical!.number }} —
+                {{ selectedRadical!.stroke_count }} traits</span
+              >
             </span>
           </span>
         </div>
@@ -150,7 +192,12 @@
         <div v-if="selectedRadical!.variants.length > 0" class="detail-block">
           <h4>Variantes</h4>
           <div class="variants-list">
-            <span v-for="v in selectedRadical!.variants" :key="v" class="variant-char">{{ v }}</span>
+            <span
+              v-for="v in selectedRadical!.variants"
+              :key="v"
+              class="variant-char"
+              >{{ v }}</span
+            >
           </div>
         </div>
 
@@ -165,7 +212,10 @@
               v-for="k in radicalKanjiList"
               :key="k.char"
               @click="selectKanji(k.char)"
-              :class="['kanji-mini-btn', { active: selectedKanjiChar === k.char }]"
+              :class="[
+                'kanji-mini-btn',
+                { active: selectedKanjiChar === k.char },
+              ]"
             >
               <span class="km-char">{{ k.char }}</span>
               <span class="km-meta">{{ k.stroke_count }}t</span>
@@ -180,7 +230,11 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
-import { fetchRadicals, fetchKanjiList, fetchKanjiDetail } from '../services/kanji'
+import {
+  fetchRadicals,
+  fetchKanjiList,
+  fetchKanjiDetail,
+} from '../services/kanji'
 import type { Radical, KanjiMeta, KanjiEntry } from '../services/kanji'
 
 const loading = ref(true)
@@ -230,7 +284,11 @@ const radicalKanjiList = computed(() => {
 
 const radicalForCurrentKanji = computed(() => {
   if (!selectedKanji.value?.radical_number) return null
-  return radicals.value.find((r) => r.number === selectedKanji.value!.radical_number) || null
+  return (
+    radicals.value.find(
+      (r) => r.number === selectedKanji.value!.radical_number,
+    ) || null
+  )
 })
 
 function selectRadical(rad: Radical) {
@@ -281,7 +339,10 @@ watch(selectedRadical, async () => {
 
 onMounted(async () => {
   try {
-    const [rads, kanjiList] = await Promise.all([fetchRadicals(), fetchKanjiList()])
+    const [rads, kanjiList] = await Promise.all([
+      fetchRadicals(),
+      fetchKanjiList(),
+    ])
     radicals.value = rads
     allKanjiMeta.value = kanjiList
   } catch {

--- a/frontend/src/views/KanjiView.vue
+++ b/frontend/src/views/KanjiView.vue
@@ -1,0 +1,810 @@
+<template>
+  <div class="kanji-grid">
+    <section class="radical-section">
+      <div class="glass-panel">
+        <div class="panel-header">
+          <span class="step-num">01</span>
+          <h2>Radicaux Kangxi (214)</h2>
+        </div>
+
+        <div class="filter-bar">
+          <div class="jlpt-filters">
+            <span class="filter-label">JLPT :</span>
+            <button
+              v-for="level in jlptLevels"
+              :key="level.label"
+              @click="selectedJlpt = level.value"
+              :class="['jlpt-btn', { active: selectedJlpt === level.value }]"
+            >
+              {{ level.label }}
+            </button>
+          </div>
+          <input
+            type="text"
+            v-model="radicalSearch"
+            placeholder="Filtrer par sens (eau, feu, main...)"
+            class="glass-input search-input"
+          />
+        </div>
+
+        <div v-if="loading" class="loading-state">
+          <span class="spinner"></span>
+          <span>Chargement des radicaux...</span>
+        </div>
+
+        <div v-else class="radical-grid">
+          <button
+            v-for="rad in filteredRadicals"
+            :key="rad.number"
+            @click="selectRadical(rad)"
+            :class="[
+              'radical-btn',
+              { active: selectedRadical?.number === rad.number },
+            ]"
+          >
+            <span class="radical-char">{{ rad.char }}</span>
+            <span class="radical-num">{{ rad.number }}</span>
+            <span class="radical-meaning">{{ rad.meaning }}</span>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="detail-section">
+      <div v-if="!selectedRadical && !selectedKanjiChar" class="glass-panel detail-placeholder">
+        <div class="placeholder-content">
+          <span class="placeholder-icon">🔍</span>
+          <h3>Sélectionnez un radical</h3>
+          <p>Parcourez les 214 radicaux Kangxi pour explorer les kanji.</p>
+        </div>
+      </div>
+
+      <div v-else-if="selectedKanji" class="glass-panel">
+        <div class="detail-header">
+          <button @click="selectedKanjiChar = null" class="back-btn">◀ Retour</button>
+        </div>
+
+        <div class="kanji-detail">
+          <div class="kanji-hero">
+            <span class="kanji-char-display">{{ selectedKanji.char }}</span>
+          </div>
+
+          <div class="kanji-info-grid">
+            <div class="info-card">
+              <span class="info-label">JLPT</span>
+              <span class="info-value">N{{ selectedKanji.jlpt_level }}</span>
+            </div>
+            <div class="info-card">
+              <span class="info-label">Traits</span>
+              <span class="info-value">{{ selectedKanji.stroke_count || '?' }}</span>
+            </div>
+            <div class="info-card">
+              <span class="info-label">Grade</span>
+              <span class="info-value">{{ selectedKanji.grade ? `第${selectedKanji.grade}` : '—' }}</span>
+            </div>
+            <div class="info-card">
+              <span class="info-label">Fréquence</span>
+              <span class="info-value">{{ selectedKanji.frequency_rank ? `#${selectedKanji.frequency_rank}` : '—' }}</span>
+            </div>
+          </div>
+
+          <div class="detail-block">
+            <h4>Lecture on'yomi (音読み)</h4>
+            <div class="yomi-tags">
+              <span v-for="y in selectedKanji.on_yomi" :key="y" class="yomi-tag on-yomi">{{ y }}</span>
+              <span v-if="selectedKanji.on_yomi.length === 0" class="no-data">—</span>
+            </div>
+          </div>
+
+          <div class="detail-block">
+            <h4>Lecture kun'yomi (訓読み)</h4>
+            <div class="yomi-tags">
+              <span v-for="y in selectedKanji.kun_yomi" :key="y" class="yomi-tag kun-yomi">{{ y }}</span>
+              <span v-if="selectedKanji.kun_yomi.length === 0" class="no-data">—</span>
+            </div>
+          </div>
+
+          <div class="detail-block">
+            <h4>Sens (EN)</h4>
+            <div class="meanings-list">
+              <span v-for="m in selectedKanji.meanings_en" :key="m" class="meaning-item">{{ m }}</span>
+            </div>
+          </div>
+
+          <div v-if="selectedKanji.components.length > 0" class="detail-block">
+            <h4>Composants</h4>
+            <div class="components-grid">
+              <span
+                v-for="c in selectedKanji.components"
+                :key="c"
+                class="component-char"
+                @click="openKanjiFromComponent(c)"
+              >
+                {{ c }}
+              </span>
+            </div>
+          </div>
+
+          <div class="detail-block">
+            <h4>Radical</h4>
+            <div class="radical-ref" @click="goToRadical(selectedKanji.radical_number!)">
+              <span class="rr-char">{{ radicalForCurrentKanji?.char }}</span>
+              <span class="rr-number">Radical {{ selectedKanji.radical_number }}</span>
+              <span class="rr-meaning">{{ radicalForCurrentKanji?.meaning }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-else class="glass-panel">
+        <div class="detail-header">
+          <span class="radical-title-display">
+            <span class="rr-big-char">{{ selectedRadical!.char }}</span>
+            <span class="rr-info">
+              <strong>{{ selectedRadical!.meaning }}</strong>
+              <span class="rr-meta">Radical {{ selectedRadical!.number }} — {{ selectedRadical!.stroke_count }} traits</span>
+            </span>
+          </span>
+        </div>
+
+        <div v-if="selectedRadical!.variants.length > 0" class="detail-block">
+          <h4>Variantes</h4>
+          <div class="variants-list">
+            <span v-for="v in selectedRadical!.variants" :key="v" class="variant-char">{{ v }}</span>
+          </div>
+        </div>
+
+        <div class="detail-block">
+          <h4>Kanji liés à ce radical ({{ radicalKanjiList.length }})</h4>
+          <div v-if="loadingKanjiForRadical" class="loading-state">
+            <span class="spinner"></span>
+            <span>Chargement...</span>
+          </div>
+          <div v-else class="kanji-grid-mini">
+            <button
+              v-for="k in radicalKanjiList"
+              :key="k.char"
+              @click="selectKanji(k.char)"
+              :class="['kanji-mini-btn', { active: selectedKanjiChar === k.char }]"
+            >
+              <span class="km-char">{{ k.char }}</span>
+              <span class="km-meta">{{ k.stroke_count }}t</span>
+              <span class="km-jlpt">N{{ k.jlpt_level }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue'
+import { fetchRadicals, fetchKanjiList, fetchKanjiDetail } from '../services/kanji'
+import type { Radical, KanjiMeta, KanjiEntry } from '../services/kanji'
+
+const loading = ref(true)
+const radicals = ref<Radical[]>([])
+const allKanjiMeta = ref<KanjiMeta[]>([])
+const selectedRadical = ref<Radical | null>(null)
+const selectedKanjiChar = ref<string | null>(null)
+const selectedKanji = ref<KanjiEntry | null>(null)
+const selectedJlpt = ref<number | null>(null)
+const radicalSearch = ref('')
+const loadingKanjiForRadical = ref(false)
+
+const jlptLevels = [
+  { label: 'Tous', value: null },
+  { label: 'N5', value: 5 },
+  { label: 'N4', value: 4 },
+  { label: 'N3', value: 3 },
+  { label: 'N2', value: 2 },
+  { label: 'N1', value: 1 },
+]
+
+const filteredRadicals = computed(() => {
+  let list = radicals.value
+  if (radicalSearch.value.trim()) {
+    const q = radicalSearch.value.toLowerCase()
+    list = list.filter(
+      (r) =>
+        r.meaning.toLowerCase().includes(q) ||
+        r.char === q ||
+        r.number.toString() === q ||
+        r.variants.some((v) => v === q),
+    )
+  }
+  return list
+})
+
+const radicalKanjiList = computed(() => {
+  if (!selectedRadical.value) return []
+  const num = selectedRadical.value.number
+  let list = allKanjiMeta.value.filter((k) => k.radical_number === num)
+  if (selectedJlpt.value !== null) {
+    list = list.filter((k) => k.jlpt_level === selectedJlpt.value)
+  }
+  list.sort((a, b) => (a.frequency_rank ?? 9999) - (b.frequency_rank ?? 9999))
+  return list
+})
+
+const radicalForCurrentKanji = computed(() => {
+  if (!selectedKanji.value?.radical_number) return null
+  return radicals.value.find((r) => r.number === selectedKanji.value!.radical_number) || null
+})
+
+function selectRadical(rad: Radical) {
+  selectedRadical.value = rad
+  selectedKanjiChar.value = null
+  selectedKanji.value = null
+}
+
+function selectKanji(char: string) {
+  selectedKanjiChar.value = char
+}
+
+function goToRadical(number: number) {
+  const rad = radicals.value.find((r) => r.number === number)
+  if (rad) {
+    selectRadical(rad)
+  }
+}
+
+function openKanjiFromComponent(char: string) {
+  const rad = radicals.value.find(
+    (r) => r.char === char || r.variants.includes(char),
+  )
+  if (rad) {
+    goToRadical(rad.number)
+    return
+  }
+  if (allKanjiMeta.value.some((k) => k.char === char)) {
+    selectKanji(char)
+  }
+}
+
+watch(selectedKanjiChar, async (char) => {
+  if (!char) {
+    selectedKanji.value = null
+    return
+  }
+  try {
+    selectedKanji.value = await fetchKanjiDetail(char)
+  } catch {
+    selectedKanji.value = null
+  }
+})
+
+watch(selectedRadical, async () => {
+  selectedKanji.value = null
+})
+
+onMounted(async () => {
+  try {
+    const [rads, kanjiList] = await Promise.all([fetchRadicals(), fetchKanjiList()])
+    radicals.value = rads
+    allKanjiMeta.value = kanjiList
+  } catch {
+    radicals.value = []
+    allKanjiMeta.value = []
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+.kanji-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.1fr;
+  gap: 30px;
+  align-items: start;
+}
+@media (max-width: 900px) {
+  .kanji-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.glass-panel {
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: 24px;
+  padding: 30px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  margin-bottom: 25px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 25px;
+}
+
+.step-num {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--primary);
+  background: rgba(236, 72, 153, 0.1);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(236, 72, 153, 0.25);
+}
+
+.panel-header h2 {
+  font-size: 1.4rem;
+  margin: 0;
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+.filter-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.jlpt-filters {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.filter-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-right: 6px;
+}
+
+.jlpt-btn {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 4px 12px;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.jlpt-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-main);
+}
+
+.jlpt-btn.active {
+  background: rgba(236, 72, 153, 0.12);
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.search-input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.glass-input {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  padding: 10px 14px;
+  color: var(--text-main);
+  font-size: 0.9rem;
+  transition: all 0.2s ease;
+  outline: none;
+  font-family: inherit;
+}
+
+.glass-input:focus {
+  border-color: var(--secondary);
+  box-shadow: 0 0 10px var(--secondary-glow);
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 40px;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.radical-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 8px;
+  max-height: 600px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.radical-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 4px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: var(--text-main);
+  font-family: inherit;
+  outline: none;
+}
+
+.radical-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+}
+
+.radical-btn.active {
+  background: rgba(236, 72, 153, 0.08);
+  border-color: var(--primary);
+  box-shadow: 0 0 8px var(--primary-glow);
+}
+
+.radical-char {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.radical-num {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.radical-meaning {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-align: center;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  white-space: nowrap;
+}
+
+.detail-placeholder .placeholder-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.placeholder-icon {
+  font-size: 3rem;
+  margin-bottom: 16px;
+}
+
+.placeholder-content h3 {
+  font-size: 1.3rem;
+  margin: 0 0 8px 0;
+  color: var(--text-main);
+}
+
+.placeholder-content p {
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.detail-header {
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+}
+
+.back-btn {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.back-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-main);
+}
+
+.radical-title-display {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.rr-big-char {
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.rr-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.rr-info strong {
+  font-size: 1.2rem;
+  color: var(--text-main);
+}
+
+.rr-meta {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.detail-block {
+  margin-bottom: 20px;
+}
+
+.detail-block h4 {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  margin: 0 0 8px 0;
+}
+
+.variants-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.variant-char {
+  font-size: 1.5rem;
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  padding: 6px 10px;
+  border-radius: 10px;
+  line-height: 1;
+}
+
+.kanji-grid-mini {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: 8px;
+  max-height: 500px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.kanji-mini-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 4px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: var(--text-main);
+  font-family: inherit;
+  outline: none;
+}
+
+.kanji-mini-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+}
+
+.kanji-mini-btn.active {
+  background: rgba(139, 92, 246, 0.1);
+  border-color: var(--secondary);
+  box-shadow: 0 0 8px var(--secondary-glow);
+}
+
+.km-char {
+  font-size: 1.4rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.km-meta {
+  font-size: 0.6rem;
+  color: var(--text-muted);
+}
+
+.km-jlpt {
+  font-size: 0.6rem;
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.kanji-hero {
+  text-align: center;
+  padding: 20px 0;
+}
+
+.kanji-char-display {
+  font-size: 4.5rem;
+  font-weight: 800;
+  text-shadow: 0 0 20px var(--primary-glow);
+  line-height: 1.2;
+}
+
+.kanji-info-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.info-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  padding: 12px;
+  text-align: center;
+}
+
+.info-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  margin-bottom: 4px;
+}
+
+.info-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+.yomi-tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.yomi-tag {
+  font-size: 0.95rem;
+  font-weight: 700;
+  padding: 4px 12px;
+  border-radius: 20px;
+  line-height: 1.3;
+}
+
+.yomi-tag.on-yomi {
+  background: rgba(139, 92, 246, 0.1);
+  border: 1px solid rgba(139, 92, 246, 0.25);
+  color: #c084fc;
+}
+
+.yomi-tag.kun-yomi {
+  background: rgba(236, 72, 153, 0.1);
+  border: 1px solid rgba(236, 72, 153, 0.25);
+  color: #f9a8d4;
+}
+
+.no-data {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.meanings-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.meaning-item {
+  font-size: 0.9rem;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  padding: 6px 14px;
+  border-radius: 20px;
+  line-height: 1.3;
+}
+
+.components-grid {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.component-char {
+  font-size: 1.6rem;
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  padding: 6px 12px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  line-height: 1;
+}
+
+.component-char:hover {
+  background: rgba(139, 92, 246, 0.1);
+  border-color: var(--secondary);
+  transform: translateY(-2px);
+}
+
+.radical-ref {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  border-radius: 14px;
+  padding: 12px 16px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.radical-ref:hover {
+  background: rgba(236, 72, 153, 0.06);
+  border-color: var(--primary);
+}
+
+.rr-char {
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.rr-number {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.rr-meaning {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-main);
+}
+</style>


### PR DESCRIPTION
- KanjiView.vue: browse 214 KangXi radicals, filter by JLPT level, view kanji per radical, full kanji detail with readings/meanings/components
- Components are clickable: opens radical if found, otherwise kanji
- HeaderSection: navigation tabs (Playground / Dico Kanji)
- AiPlayground: KanjiView integration
- catalog.rs: fix DeckFile parsing (cards sibling of deck, not nested)
- main.rs: boot log includes kanji/radical counts