### PR TITLE
fix: single-anime freq extraction with proper stdin handling, Shift-J…

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -21,6 +21,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +76,7 @@ name = "lwm-tools"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "encoding_rs",
  "quick-xml",
  "serde",
  "serde_json",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -33,3 +33,4 @@ serde_json = "1"
 quick-xml = "0.31"
 anyhow = "1"
 uuid = { version = "1", features = ["v5"] }
+encoding_rs = "0.8"

--- a/tools/process_anime.sh
+++ b/tools/process_anime.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+SOURCE="${1:-_sources/JP-Subtitles}"
+MIN="${2:-3}"
+for dir in "$SOURCE"/*/; do
+    name=$(basename "$dir")
+    echo "=== $name ==="
+    cargo run --bin extract-anime-freq -- "$dir" --min-count "$MIN" 2>&1
+done
+echo "=== ALL DONE ==="

--- a/tools/src/extract_anime_freq.rs
+++ b/tools/src/extract_anime_freq.rs
@@ -1,164 +1,197 @@
 use std::collections::HashMap;
+use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Stdio};
+use std::time::Instant;
 
-struct Args {
-    sources: Vec<PathBuf>,
-    merge: bool,
-}
-
-fn parse_args() -> Args {
-    let mut sources = Vec::new();
-    let mut merge = false;
-    let mut i = 1;
-    let raw: Vec<String> = std::env::args().collect();
-    while i < raw.len() {
-        match raw[i].as_str() {
-            "--source" => {
-                i += 1;
-                sources.push(PathBuf::from(&raw[i]));
-            }
-            "--merge" => merge = true,
-            other => {
-                eprintln!("Unknown arg: {}", other);
-                std::process::exit(1);
-            }
-        }
-        i += 1;
-    }
-    if sources.is_empty() {
-        sources.push(
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("_sources")
-                .join("JP-Subtitles"),
-        );
-    }
-    Args { sources, merge }
-}
+const SKIP_POS: &[&str] = &[
+    "助詞", "助動詞", "記号", "補助記号", "接続詞", "連体詞", "フィラー", "接頭詞",
+];
 
 fn main() {
-    let args = parse_args();
-    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let output_dir = root.join("data").join("anime_freq");
-    fs::create_dir_all(&output_dir).expect("Cannot create anime_freq dir");
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <anime-dir> [--merge] [--min-count N]", args[0]);
+        std::process::exit(1);
+    }
 
-    // Verify mecab
+    let anime_dir = Path::new(&args[1]);
+    let merge = args.contains(&"--merge".to_string());
+    let min_count = args.windows(2)
+        .find(|w| w[0] == "--min-count")
+        .and_then(|w| w[1].parse().ok())
+        .unwrap_or(1u64);
+
+    if !anime_dir.is_dir() {
+        eprintln!("❌ Not a directory: {}", anime_dir.display());
+        std::process::exit(1);
+    }
+
     if Command::new("mecab").arg("--version").output().is_err() {
         eprintln!("❌ mecab not found. Install with: brew install mecab mecab-ipadic");
         std::process::exit(1);
     }
 
-    // Count total anime across all sources
-    let mut all_anime: Vec<(String, PathBuf)> = Vec::new(); // (name, dir)
-    for src in &args.sources {
-        if !src.exists() {
-            eprintln!("⚠️ Source not found: {}", src.display());
-            continue;
-        }
-        let entries = match fs::read_dir(src) {
-            Ok(e) => e,
-            Err(e) => {
-                eprintln!("⚠️ Cannot read {}: {}", src.display(), e);
-                continue;
-            }
-        };
-        for entry in entries {
-            let entry = match entry {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            if let Some(name) = entry.file_name().to_str() {
-                if name.starts_with('.') {
-                    continue;
-                }
-                all_anime.push((name.to_string(), path));
-            }
-        }
+    let anime_name = anime_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let output_dir = root.join("data").join("anime_freq");
+    fs::create_dir_all(&output_dir).expect("Cannot create anime_freq dir");
+
+    let slug = slugify(anime_name);
+
+    // Collect subtitle files
+    let files = collect_subtitle_files(anime_dir);
+    if files.is_empty() {
+        eprintln!("⚠️ {}: no .srt / .ass files found", anime_name);
+        std::process::exit(0);
     }
-    all_anime.sort_by(|a, b| a.0.cmp(&b.0));
+    println!("📁 {} ({} files)", anime_name, files.len());
 
-    let total = all_anime.len();
-    println!("📂 {} anime found across {} source(s)", total, args.sources.len());
-    println!("🔧 Initializing MeCab...");
+    // Extract text from all files
+    let mut all_text = String::new();
+    let mut files_with_jp = 0usize;
+    for f in &files {
+        let fname = Path::new(f)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(f);
 
-    // How to count total effort: we'll collect subtitle files for each anime first
-    // Use a single persistent mecab process
-    println!("📖 Processing...");
-
-    for (idx, (anime_name, anime_dir)) in all_anime.iter().enumerate() {
-        let files = collect_subtitle_files_recursive(anime_dir);
-
-        if files.is_empty() {
-            println!("   [{}/{}] {} (skipped)", idx + 1, total, anime_name);
-            std::io::stdout().flush().ok();
-            continue;
-        }
-
-        let text = extract_text_from_files(&files);
-        if text.trim().is_empty() {
-            println!("   [{}/{}] {} (no text)", idx + 1, total, anime_name);
-            std::io::stdout().flush().ok();
-            continue;
-        }
-
-        println!("   [{}/{}] {} → parsing {} files...", idx + 1, total, anime_name, files.len());
-        std::io::stdout().flush().ok();
-
-        let word_counts = match count_words_mecab(&text) {
-            Ok(map) => map,
+        let raw = match fs::read(f) {
+            Ok(b) => b,
             Err(e) => {
-                eprintln!("   ⚠️ {}: {}", anime_name, e);
+                eprintln!("   ⚠️ {}: {}", fname, e);
                 continue;
             }
         };
 
-        if word_counts.is_empty() {
-            println!("   [{}/{}] {} (0 words)", idx + 1, total, anime_name);
-            std::io::stdout().flush().ok();
-            continue;
-        }
+        let content = match String::from_utf8(raw) {
+            Ok(s) => s,
+            Err(e) => {
+                let bytes = e.into_bytes();
+                let (decoded, _, _) = encoding_rs::SHIFT_JIS.decode(&bytes);
+                decoded.to_string()
+            }
+        };
 
-        let slug = slugify(anime_name);
-        let out_path = output_dir.join(format!("{}.jsonl", slug));
-
-        // Load existing counts if --merge
-        let mut merged = if args.merge && out_path.exists() {
-            load_existing_counts(&out_path)
+        let mut extracted = String::new();
+        if f.ends_with(".ass") {
+            extract_ass_text(&content, &mut extracted);
         } else {
-            HashMap::new()
-        };
-
-        // Add new counts
-        for (word, count) in &word_counts {
-            *merged.entry(word.clone()).or_insert(0) += count;
+            extract_srt_text(&content, &mut extracted);
         }
 
-        // Write output
-        let mut content = String::new();
-        let mut entries: Vec<(&str, u64)> =
-            merged.iter().map(|(w, c)| (w.as_str(), *c)).collect();
-        entries.sort_by(|a, b| b.1.cmp(&a.1));
-        for (word, count) in &entries {
-            content.push_str(
-                &serde_json::json!({ "word": word, "count": count }).to_string(),
-            );
-            content.push('\n');
+        if !extracted.trim().is_empty() {
+            files_with_jp += 1;
+            all_text.push_str(&extracted);
         }
-        fs::write(&out_path, &content).expect("Cannot write anime freq file");
-
-        let pct = (idx + 1) as f64 / total as f64 * 100.0;
-        println!("   [{}/{}] {}: {} words, {} files ({:.0}%)",
-            idx + 1, total, anime_name, merged.len(), files.len(), pct);
-        std::io::stdout().flush().ok();
     }
 
-    println!("\n✅ Done! {} anime in {}", all_anime.len(), output_dir.display());
+    if all_text.trim().is_empty() {
+        eprintln!("⚠️ {}: no Japanese text found", anime_name);
+        std::process::exit(0);
+    }
+
+    println!("   {} files with Japanese text", files_with_jp);
+
+    let mecab_start = Instant::now();
+    let mut child = Command::new("mecab")
+        .arg("-b")
+        .arg("262144")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Cannot spawn mecab");
+
+    let mut child_stdin = child.stdin.take().unwrap();
+    let child_stdout = child.stdout.take().unwrap();
+    let text_bytes = all_text.as_bytes().to_vec();
+
+    let writer = std::thread::spawn(move || {
+        child_stdin.write_all(&text_bytes).unwrap();
+    });
+
+    let reader = BufReader::new(child_stdout);
+    let mut counts: HashMap<String, u64> = HashMap::new();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let line = line.trim().to_string();
+        if line.is_empty() || line == "EOS" {
+            continue;
+        }
+
+        let parts: Vec<&str> = line.split('\t').collect();
+        if parts.len() < 2 {
+            continue;
+        }
+        let surface = parts[0];
+        let features: Vec<&str> = parts[1].split(',').collect();
+        if features.is_empty() {
+            continue;
+        }
+
+        let pos = features[0];
+        if SKIP_POS.contains(&pos) {
+            continue;
+        }
+        if surface.len() < 2 {
+            continue;
+        }
+        let word = features.get(6).unwrap_or(&surface);
+        if word.len() < 2 {
+            continue;
+        }
+        *counts.entry(word.to_string()).or_insert(0) += 1;
+    }
+
+    writer.join().unwrap();
+    let _ = child.wait();
+    let mecab_elapsed = mecab_start.elapsed().as_secs_f64();
+
+    let out_path = output_dir.join(format!("{}.jsonl", slug));
+
+    // Merge existing counts if --merge
+    let mut merged = if merge && out_path.exists() {
+        load_existing_counts(&out_path)
+    } else {
+        HashMap::new()
+    };
+    for (word, count) in &counts {
+        *merged.entry(word.clone()).or_insert(0) += count;
+    }
+
+    // Write output sorted by frequency (filtering by min_count)
+    let mut content = String::new();
+    let mut entries: Vec<(&str, u64)> =
+        merged.iter().map(|(w, c)| (w.as_str(), *c)).collect();
+    entries.sort_by(|a, b| b.1.cmp(&a.1));
+    for (word, count) in &entries {
+        if *count < min_count {
+            continue;
+        }
+        content.push_str(&serde_json::json!({ "word": word, "count": count }).to_string());
+        content.push('\n');
+    }
+    fs::write(&out_path, &content).expect("Cannot write freq file");
+
+    println!(
+        "   ✅ {} words unique (min {}+), {} total, mecab {:.2}s → {}",
+        merged.iter().filter(|(_, c)| **c >= min_count).count(),
+        min_count,
+        merged.values().sum::<u64>(),
+        mecab_elapsed,
+        out_path.file_name().unwrap().to_string_lossy()
+    );
 }
 
 fn load_existing_counts(path: &Path) -> HashMap<String, u64> {
@@ -183,13 +216,13 @@ fn load_existing_counts(path: &Path) -> HashMap<String, u64> {
     map
 }
 
-fn collect_subtitle_files_recursive(dir: &Path) -> Vec<String> {
+fn collect_subtitle_files(dir: &Path) -> Vec<String> {
     let mut files = Vec::new();
-    collect_subtitle_files_inner(dir, &mut files);
+    collect_files_inner(dir, &mut files);
     files
 }
 
-fn collect_subtitle_files_inner(dir: &Path, files: &mut Vec<String>) {
+fn collect_files_inner(dir: &Path, files: &mut Vec<String>) {
     let entries = match fs::read_dir(dir) {
         Ok(e) => e,
         Err(_) => return,
@@ -201,31 +234,15 @@ fn collect_subtitle_files_inner(dir: &Path, files: &mut Vec<String>) {
         };
         let path = entry.path();
         if path.is_dir() {
-            collect_subtitle_files_inner(&path, files);
+            collect_files_inner(&path, files);
         } else if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-            if ext == "srt" || ext == "ass" || ext == "txt" {
+            if ext == "srt" || ext == "ass" {
                 if let Some(p) = path.to_str() {
                     files.push(p.to_string());
                 }
             }
         }
     }
-}
-
-fn extract_text_from_files(files: &[String]) -> String {
-    let mut all_text = String::new();
-    for f in files {
-        let content = match fs::read_to_string(f) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        if f.ends_with(".ass") {
-            extract_ass_text(&content, &mut all_text);
-        } else {
-            extract_srt_text(&content, &mut all_text);
-        }
-    }
-    all_text
 }
 
 fn extract_srt_text(content: &str, out: &mut String) {
@@ -266,11 +283,7 @@ fn extract_ass_text(content: &str, out: &mut String) {
             if parts.len() >= 10 {
                 let style = parts[3].trim();
                 let text = parts[9];
-                if style.contains("JP")
-                    || style.contains("Default")
-                    || style.contains("ED-")
-                    || style.contains("OP-")
-                {
+                if style.contains("JP") || style.contains("Default") {
                     let cleaned = text
                         .replace("\\N", " ")
                         .replace("\\n", " ")
@@ -296,81 +309,6 @@ fn has_japanese(s: &str) -> bool {
             || (cp >= 0x4E00 && cp <= 0x9FFF)
             || (cp >= 0x3400 && cp <= 0x4DBF)
     })
-}
-
-fn count_words_mecab(text: &str) -> Result<HashMap<String, u64>, String> {
-    let mut child = Command::new("mecab")
-        .arg("-b")
-        .arg("65536")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("Cannot spawn mecab: {}", e))?;
-
-    {
-        let stdin = child.stdin.as_mut().unwrap();
-        for line in text.lines() {
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-            writeln!(stdin, "{}", line)
-                .map_err(|e| format!("Cannot write to mecab: {}", e))?;
-        }
-    }
-
-    let reader = BufReader::new(child.stdout.take().unwrap());
-    let mut counts: HashMap<String, u64> = HashMap::new();
-
-    let skip_pos = &[
-        "助詞", "助動詞", "記号", "補助記号", "接続詞", "連体詞", "フィラー", "接頭詞",
-    ];
-
-    for line in reader.lines() {
-        let line = line.map_err(|e| format!("Cannot read mecab output: {}", e))?;
-        let line = line.trim();
-        if line.is_empty() || line == "EOS" {
-            continue;
-        }
-
-        let parts: Vec<&str> = line.split('\t').collect();
-        if parts.len() < 2 {
-            continue;
-        }
-
-        let surface = parts[0];
-        let features: Vec<&str> = parts[1].split(',').collect();
-        if features.is_empty() {
-            continue;
-        }
-
-        let pos = features[0];
-
-        if skip_pos.contains(&pos) {
-            continue;
-        }
-
-        if surface.len() < 2 {
-            continue;
-        }
-
-        let word = features.get(6).unwrap_or(&surface);
-        if word.len() < 2 {
-            continue;
-        }
-
-        *counts.entry(word.to_string()).or_insert(0) += 1;
-    }
-
-    let status = child
-        .wait()
-        .map_err(|e| format!("Cannot wait for mecab: {}", e))?;
-    if !status.success() {
-        return Err(format!("mecab exited with: {:?}", status.code()));
-    }
-
-    Ok(counts)
 }
 
 fn slugify(s: &str) -> String {


### PR DESCRIPTION
…IS support, and --min-count filter

- Fixed pipe deadlock: write mecab input in a thread while reading stdout
- Fixed stdin not being closed (mecab waited for EOF forever)
- Per-anime invocation: clean process per anime, easy resume
- Shift-JIS decoding for ASS files (Kamigami releases)
- --min-count N flag to filter rare words (default 1)
- process_anime.sh wrapper script for batch processing
- encoding_rs dependency for Japanese encoding support